### PR TITLE
Replace double quotes with single quotes and remove commas

### DIFF
--- a/grammars/coffee haml.cson
+++ b/grammars/coffee haml.cson
@@ -141,17 +141,17 @@
     ]
   }
   {
-    "begin": "#\{",
-    "captures": {
-      "0": {
-        "name": "punctuation.section.embedded.coffee"
+    'begin': '#\{'
+    'captures': {
+      '0': {
+        'name': 'punctuation.section.embedded.coffee'
       }
-    },
-    "end": "}",
-    "name": "source.coffee.embedded.html",
-    "patterns": [
+    }
+    'end': '}'
+    'name': 'source.coffee.embedded.html'
+    'patterns': [
       {
-        "include": "source.coffee"
+        'include': 'source.coffee'
       }
     ]
   }

--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -180,17 +180,17 @@
     ]
   }
   {
-    "begin": "^(?!-#).*?#\{",
-    "captures": {
-      "0": {
-        "name": "punctuation.section.embedded.ruby"
+    'begin': '^(?!-#).*?#\{'
+    'captures': {
+      '0': {
+        'name': 'punctuation.section.embedded.ruby'
       }
     },
-    "end": "}",
-    "name": "source.ruby.rails.embedded.html",
-    "patterns": [
+    'end': '}'
+    'name': 'source.ruby.rails.embedded.html'
+    'patterns': [
       {
-        "include": "source.ruby.rails"
+        'include': 'source.ruby.rails'
       }
     ]
   }


### PR DESCRIPTION
This allows Atom to once again load language-haml on my machine and restores syntax highlighting