### PR TITLE
Fixed end of attributes regexp

### DIFF
--- a/grammars/ruby haml.cson
+++ b/grammars/ruby haml.cson
@@ -53,7 +53,7 @@
       }
       {
         'begin': '\\{(?=.*\\}|.*(\\||,)\\s*$)'
-        'end': '\\}'
+        'end': '\\}(?!\\s*,)'
         'name': 'meta.section.attributes.haml'
         'patterns': [
           {


### PR DESCRIPTION
This fix will turn
![image](https://cloud.githubusercontent.com/assets/46217/6480624/fb7dc0b6-c27f-11e4-9f1b-cd4164744abc.png)

To this
![image](https://cloud.githubusercontent.com/assets/46217/6480592/a4fc14a4-c27f-11e4-821f-ff4bcda1400f.png)
